### PR TITLE
Replace arrow function for es5 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function loadScriptOnce (src, callback) {
     promise = cache[src] = doLoad(src)
 
     // On error, fail to allow retry
-    promise.catch(() => {
+    promise.catch(function () {
       delete cache[src]
     })
   }


### PR DESCRIPTION
With arrow functions, an additional transpileDependencies option would be required to add to Webpack config to fix compatibility, or it will pop errors in older browsers. Change arrow function back to normal one to avoid this error.